### PR TITLE
Disable the ocaml detection for the dune port

### DIFF
--- a/raw/configure
+++ b/raw/configure
@@ -516,11 +516,6 @@ else
   echo "#define HACL_CAN_COMPILE_UINT128 1" >> config.h
 fi
 
-if [[ "$disable_ocaml" == "1" ]] || ! detect_ocaml; then
-  echo "OCaml bindings disabled"
-  echo "DISABLE_OCAML_BINDINGS=1" >> Makefile.config
-fi
-
 if [[ $target_sys == "Linux" ]]; then
   if [[ "$disable_bzero" == "1" ]]; then
     echo "disabling the use of explicit_bzero"


### PR DESCRIPTION
This is used to determine whether the ocamlbindings should be built. Given we're specifically in the dune port there's no point in running this as we obviously want the ocaml bindings.

It's probably worth working on a better version by making this configurable so that the dune rules always enables them or to eventually make the detection more robust in the future.